### PR TITLE
Port change from 8080 to 8081 at folderServicePath

### DIFF
--- a/www/js/services/path.js
+++ b/www/js/services/path.js
@@ -5,7 +5,7 @@ angular.module('starter.controllers')
   this.userServicePath = "http://210.121.158.168:5001";
   this.reviewServicePath = "http://210.121.158.165:8080";
   this.fileServicePath = "http://210.121.158.170:8080";
-  this.folderServicePath = "http://210.121.158.166:8080";
+  this.folderServicePath = "http://210.121.158.166:8081";
   this.publishDocumentServicePath = "http://localhost:8086";
   this.approverListServicePath = "http://210.121.158.162:8080";
 })


### PR DESCRIPTION
I try to connect dms-front service in my PC, but I can't get the doc lists (related with folderServicePath).
After change Port number 8080 to 8081 (wrote in your thesis), it's work correctly.
So, I think Port number should better to be changed.